### PR TITLE
Improve mobile compatibility

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,11 @@ export const metadata: Metadata = {
   description: "Professional/Personal record of Hyunwoo Lee",
 };
 
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/components/disccoHeader.tsx
+++ b/components/disccoHeader.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+"use client";
+import React, { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import DropdownButton from "@/components/ui/dropdownButton"
+import { Menu } from "lucide-react"
 
 const DiscoHeader: React.FC = () => {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   return (
-    <header className="flex items-center justify-between px-6 py-4 bg-gray-900 text-white sticky top-0 z-40">
+    <header className="relative flex items-center justify-between px-6 py-4 bg-gray-900 text-white sticky top-0 z-40">
       <div className="flex items-center">
         <Link href='/disco'>
           <Image
@@ -21,7 +24,7 @@ const DiscoHeader: React.FC = () => {
             <span className="text-xl font-bold">JadeHouse Disco</span>
         </Link>
       </div>
-      <div className="flex space-x-4 font-bold text-lg">
+      <nav className="hidden md:flex space-x-4 font-bold text-lg">
         <DropdownButton
           href='/disco'
           options={undefined}
@@ -47,7 +50,29 @@ const DiscoHeader: React.FC = () => {
           options={undefined}
           buttonText="Music"
         />
-      </div>
+      </nav>
+      <button className="md:hidden" onClick={() => setMobileMenuOpen(!mobileMenuOpen)}>
+        <Menu className="h-6 w-6" />
+      </button>
+      {mobileMenuOpen && (
+        <div className="absolute top-full left-0 w-full bg-gray-900 flex flex-col items-center space-y-2 py-2 md:hidden">
+          <Link href='/disco' className="font-bold" onClick={() => setMobileMenuOpen(false)}>
+            Home
+          </Link>
+          <Link href='/disco/aboutme' className="font-bold" onClick={() => setMobileMenuOpen(false)}>
+            About
+          </Link>
+          <Link href='/disco/memories' className="font-bold" onClick={() => setMobileMenuOpen(false)}>
+            Memories
+          </Link>
+          <Link href='/disco/thoughts' className="font-bold" onClick={() => setMobileMenuOpen(false)}>
+            Thoughts
+          </Link>
+          <Link href='/disco/music' className="font-bold" onClick={() => setMobileMenuOpen(false)}>
+            Music
+          </Link>
+        </div>
+      )}
     </header>
   );
 };

--- a/components/labHeader.tsx
+++ b/components/labHeader.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+"use client";
+import React, { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import DropdownButton from "@/components/ui/dropdownButton"
+import { Menu } from "lucide-react"
 
 const LabHeader: React.FC = () => {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   return (
-    <header className="flex items-center justify-between px-6 py-4 bg-gray-900 text-white sticky top-0 z-40">
+    <header className="relative flex items-center justify-between px-6 py-4 bg-gray-900 text-white sticky top-0 z-40">
       <div className="flex items-center">
         <Link href="/lab">
           <Image
@@ -21,7 +24,7 @@ const LabHeader: React.FC = () => {
             <span className="text-xl font-bold">JadeHouse Lab</span>
         </Link>
       </div>
-      <div className="flex space-x-4 font-bold text-lg">
+      <nav className="hidden md:flex space-x-4 font-bold text-lg">
           <DropdownButton
             href="/lab"
             options={undefined}
@@ -43,11 +46,33 @@ const LabHeader: React.FC = () => {
             buttonText='Ideas'
           />
            <DropdownButton
-            href='/lab/litrev'
-            options={undefined}
-            buttonText='Literature Reviews'
+           href='/lab/litrev'
+           options={undefined}
+           buttonText='Literature Reviews'
           />
-      </div>
+      </nav>
+      <button className="md:hidden" onClick={() => setMobileMenuOpen(!mobileMenuOpen)}>
+        <Menu className="h-6 w-6" />
+      </button>
+      {mobileMenuOpen && (
+        <div className="absolute top-full left-0 w-full bg-gray-900 flex flex-col items-center space-y-2 py-2 md:hidden">
+          <Link href='/lab' className="font-bold" onClick={() => setMobileMenuOpen(false)}>
+            Home
+          </Link>
+          <Link href='/lab/aboutme' className="font-bold" onClick={() => setMobileMenuOpen(false)}>
+            About
+          </Link>
+          <Link href='/lab/experiences' className="font-bold" onClick={() => setMobileMenuOpen(false)}>
+            Experiences
+          </Link>
+          <Link href='/lab/ideas' className="font-bold" onClick={() => setMobileMenuOpen(false)}>
+            Ideas
+          </Link>
+          <Link href='/lab/litrev' className="font-bold" onClick={() => setMobileMenuOpen(false)}>
+            Literature Reviews
+          </Link>
+        </div>
+      )}
     </header>
   );
 };

--- a/components/mainHeader.tsx
+++ b/components/mainHeader.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+"use client";
+import React, { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import DropdownButton from "@/components/ui/dropdownButton"
+import { Menu } from "lucide-react"
 
 const MainHeader: React.FC = () => {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   return (
-    <header className="flex items-center justify-between px-6 py-4 bg-gray-900 text-white sticky top-0 z-40">
+    <header className="relative flex items-center justify-between px-6 py-4 bg-gray-900 text-white sticky top-0 z-40">
       <div className="flex items-center">
         <Link href='/'>
           <Image
@@ -21,7 +24,7 @@ const MainHeader: React.FC = () => {
             <span className="text-xl font-bold">JadeHouse</span>
         </Link>
       </div>
-      <div className="flex space-x-4 font-bold text-lg">
+      <nav className="hidden md:flex space-x-4 font-bold text-lg">
         <DropdownButton
           href='/lab'
           options={undefined}
@@ -32,7 +35,20 @@ const MainHeader: React.FC = () => {
           options={undefined}
           buttonText="Disco"
         />
-      </div>
+      </nav>
+      <button className="md:hidden" onClick={() => setMobileMenuOpen(!mobileMenuOpen)}>
+        <Menu className="h-6 w-6" />
+      </button>
+      {mobileMenuOpen && (
+        <div className="absolute top-full left-0 w-full bg-gray-900 flex flex-col items-center space-y-2 py-2 md:hidden">
+          <Link href='/lab' className="font-bold" onClick={() => setMobileMenuOpen(false)}>
+            Lab
+          </Link>
+          <Link href='/disco' className="font-bold" onClick={() => setMobileMenuOpen(false)}>
+            Disco
+          </Link>
+        </div>
+      )}
     </header>
   );
 };

--- a/components/pages/disco/memories/cambodia/cambodia.tsx
+++ b/components/pages/disco/memories/cambodia/cambodia.tsx
@@ -52,7 +52,7 @@ const Cambodia = () => {
           {/*blogPostContents*/}
           <div className="relative flex">
 
-            <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+            <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
               <h2 className="text-3xl font-bold mb-4">Contents</h2>
               <ul>
                 {headings.map(heading => (

--- a/components/pages/disco/memories/daebudo/daebudo.tsx
+++ b/components/pages/disco/memories/daebudo/daebudo.tsx
@@ -52,7 +52,7 @@ const Daebudo = () => {
           {/*blogPostContents*/}
           <div className="relative flex">
 
-            <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+            <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
               <h2 className="text-3xl font-bold mb-4">Contents</h2>
               <ul>
                 {headings.map(heading => (

--- a/components/pages/disco/memories/korea/korea.tsx
+++ b/components/pages/disco/memories/korea/korea.tsx
@@ -52,7 +52,7 @@ const Korea = () => {
           {/*blogPostContents*/}
           <div className="relative flex">
 
-            <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+            <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
               <h2 className="text-3xl font-bold mb-4">Contents</h2>
               <ul>
                 {headings.map(heading => (

--- a/components/pages/disco/memories/military/military.tsx
+++ b/components/pages/disco/memories/military/military.tsx
@@ -52,7 +52,7 @@ const Military = () => {
           {/*blogPostContents*/}
           <div className="relative flex">
 
-            <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+            <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
               <h2 className="text-3xl font-bold mb-4">Contents</h2>
               <ul>
                 {headings.map(heading => (

--- a/components/pages/disco/memories/singaporePre/singaporePre.tsx
+++ b/components/pages/disco/memories/singaporePre/singaporePre.tsx
@@ -52,7 +52,7 @@ const SingaporePre = () => {
           {/*blogPostContents*/}
           <div className="relative flex">
 
-            <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+            <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
               <h2 className="text-3xl font-bold mb-4">Contents</h2>
               <ul>
                 {headings.map(heading => (

--- a/components/pages/disco/thoughts/leaders/leaders.tsx
+++ b/components/pages/disco/thoughts/leaders/leaders.tsx
@@ -52,7 +52,7 @@ const Leaders = () => {
           {/*blogPostContents*/}
           <div className="relative flex">
 
-            <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+            <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
               <h2 className="text-3xl font-bold mb-4">Contents</h2>
               <ul>
                 {headings.map(heading => (

--- a/components/pages/disco/thoughts/life/life.tsx
+++ b/components/pages/disco/thoughts/life/life.tsx
@@ -52,7 +52,7 @@ const Life = () => {
           {/*blogPostContents*/}
           <div className="relative flex">
 
-            <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+            <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
               <h2 className="text-3xl font-bold mb-4">Contents</h2>
               <ul>
                 {headings.map(heading => (

--- a/components/pages/lab/experiences/SENSE/SENSE.tsx
+++ b/components/pages/lab/experiences/SENSE/SENSE.tsx
@@ -53,7 +53,7 @@ const SENSE = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/experiences/delta/delta.tsx
+++ b/components/pages/lab/experiences/delta/delta.tsx
@@ -52,7 +52,7 @@ const Delta = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/experiences/dyson/dyson.tsx
+++ b/components/pages/lab/experiences/dyson/dyson.tsx
@@ -53,7 +53,7 @@ const Dyson = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/experiences/fyp/fyp.tsx
+++ b/components/pages/lab/experiences/fyp/fyp.tsx
@@ -53,7 +53,7 @@ const Fyp = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/experiences/martdeliv/martdeliv.tsx
+++ b/components/pages/lab/experiences/martdeliv/martdeliv.tsx
@@ -53,7 +53,7 @@ const Martdeliv = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/experiences/snu/snu.tsx
+++ b/components/pages/lab/experiences/snu/snu.tsx
@@ -53,7 +53,7 @@ const Snu = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/experiences/ureca/ureca.tsx
+++ b/components/pages/lab/experiences/ureca/ureca.tsx
@@ -53,7 +53,7 @@ const Ureca = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/ideas/HFPhtm/HFPhtm.tsx
+++ b/components/pages/lab/ideas/HFPhtm/HFPhtm.tsx
@@ -52,7 +52,7 @@ const HFPhtm = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/ideas/HydroElec/HydroElec.tsx
+++ b/components/pages/lab/ideas/HydroElec/HydroElec.tsx
@@ -52,7 +52,7 @@ const HydroElec = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/ideas/UFHF/UFHF.tsx
+++ b/components/pages/lab/ideas/UFHF/UFHF.tsx
@@ -52,7 +52,7 @@ const UFHF = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/ideas/VRR/VRR.tsx
+++ b/components/pages/lab/ideas/VRR/VRR.tsx
@@ -52,7 +52,7 @@ const VRR = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/ideas/armHead/armHead.tsx
+++ b/components/pages/lab/ideas/armHead/armHead.tsx
@@ -52,7 +52,7 @@ const ArmHead = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (  

--- a/components/pages/lab/ideas/bldPwr/bldPwr.tsx
+++ b/components/pages/lab/ideas/bldPwr/bldPwr.tsx
@@ -52,7 +52,7 @@ const BldPwr = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/ideas/expnArm/expnArm.tsx
+++ b/components/pages/lab/ideas/expnArm/expnArm.tsx
@@ -52,7 +52,7 @@ const ExpnArm = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/ideas/intRecg/intRecg.tsx
+++ b/components/pages/lab/ideas/intRecg/intRecg.tsx
@@ -52,7 +52,7 @@ const IntRecg = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/ideas/tapeCut/tapeCut.tsx
+++ b/components/pages/lab/ideas/tapeCut/tapeCut.tsx
@@ -52,7 +52,7 @@ const TapeCut = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/ideas/tripleA/tripleA.tsx
+++ b/components/pages/lab/ideas/tripleA/tripleA.tsx
@@ -52,7 +52,7 @@ const TripleA = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/ideas/univExsk/univExsk.tsx
+++ b/components/pages/lab/ideas/univExsk/univExsk.tsx
@@ -52,7 +52,7 @@ const UnivExsk = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/ideas/visCtr/visCtr.tsx
+++ b/components/pages/lab/ideas/visCtr/visCtr.tsx
@@ -52,7 +52,7 @@ const VisCtr = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (

--- a/components/pages/lab/litrev/HFpEFDev/HFpEFDev.tsx
+++ b/components/pages/lab/litrev/HFpEFDev/HFpEFDev.tsx
@@ -52,7 +52,7 @@ const HFpEFDev = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (  

--- a/components/pages/lab/litrev/humSVCOccl/humSVCOccl.tsx
+++ b/components/pages/lab/litrev/humSVCOccl/humSVCOccl.tsx
@@ -52,7 +52,7 @@ const HumSVCOccl = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (  

--- a/components/pages/lab/litrev/itmtSVCOccl/itmtSVCOccl.tsx
+++ b/components/pages/lab/litrev/itmtSVCOccl/itmtSVCOccl.tsx
@@ -52,7 +52,7 @@ const ItmtSVCOccl = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (  

--- a/components/pages/lab/litrev/lwrLimbsEMG/lwrLimbsEMG.tsx
+++ b/components/pages/lab/litrev/lwrLimbsEMG/lwrLimbsEMG.tsx
@@ -52,7 +52,7 @@ const LwrLimbsEMG = () => {
             {/*blogPostContents*/}
             <div className="relative flex">
 
-              <nav className="sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
+              <nav className="hidden md:block sticky top-0 flex-none w-56 h-screen py-8 pl-8 bg-black overflow-y-auto">
                 <h2 className="text-3xl font-bold mb-4">Contents</h2>
                 <ul>
                   {headings.map(heading => (  


### PR DESCRIPTION
## Summary
- add viewport meta for responsive scaling
- update headers with mobile menu
- hide sidebar nav on small screens

## Testing
- `npm run lint` *(fails: Next.js prompts interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_686ab72701908329bb4102908e52e9ba