### PR TITLE
fix: guard sendgrid API key

### DIFF
--- a/app/api/sendEmail/route.js
+++ b/app/api/sendEmail/route.js
@@ -1,7 +1,5 @@
 import sendgrid from "@sendgrid/mail";
 
-sendgrid.setApiKey(process.env.SENDGRID_API_KEY);
-
 export async function POST(req) {
   try {
     const { email, message } = await req.json();
@@ -10,6 +8,17 @@ export async function POST(req) {
       return new Response(JSON.stringify({ error: "Email and message are required" }), { status: 400 });
     }
 
+    const apiKey = process.env.SENDGRID_API_KEY;
+    if (!apiKey) {
+      console.error("SENDGRID_API_KEY is not set");
+      return new Response(
+        JSON.stringify({ error: "Email service is not configured" }),
+        { status: 500 }
+      );
+    }
+
+    sendgrid.setApiKey(apiKey);
+
     await sendgrid.send({
       to: "HYUNWOO001@e.ntu.edu.sg",
       from: "alexlee2459@gmail.com",
@@ -17,7 +26,10 @@ export async function POST(req) {
       html: `<h1>From: ${email}</h1><p>${message}</p>`,
     });
 
-    return new Response(JSON.stringify({ error: "" }), { status: 200 });
+    return new Response(
+      JSON.stringify({ message: "Email sent" }),
+      { status: 200 }
+    );
   } catch (error) {
     console.error(error);
     return new Response(JSON.stringify({ error: error.message }), { status: 500 });


### PR DESCRIPTION
## Summary
- handle missing SENDGRID_API_KEY in sendEmail API route
- clarify successful response message when sending email

## Testing
- `npm run build`
- `npm run lint` *(fails: prompt requires manual ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689f2a59f8c08329808124f2c9186b06