### PR TITLE
Add parallax image scroll component

### DIFF
--- a/components/ui/parallaxScroll.tsx
+++ b/components/ui/parallaxScroll.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Image from "next/image";
+import React, { useEffect, useRef } from "react";
+
+interface ParallaxLayer {
+  src: string;
+  speed: number;
+  alt?: string;
+}
+
+interface ParallaxScrollProps {
+  layers: ParallaxLayer[];
+  className?: string;
+}
+
+const ParallaxScroll: React.FC<ParallaxScrollProps> = ({ layers, className }) => {
+  const layerRefs = useRef<HTMLDivElement[]>([]);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollY = window.scrollY;
+      layerRefs.current.forEach((el, index) => {
+        if (!el) return;
+        const speed = layers[index].speed;
+        el.style.transform = `translateY(${scrollY * speed}px)`;
+      });
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [layers]);
+
+  return (
+    <div className={`relative w-full h-screen overflow-hidden ${className || ""}`}>
+      {layers.map((layer, idx) => (
+        <div
+          key={idx}
+          ref={(el) => {
+            if (el) {
+              layerRefs.current[idx] = el;
+            }
+          }}
+          className="absolute top-0 left-0 w-full h-full pointer-events-none"
+          style={{ willChange: "transform" }}
+        >
+          <Image
+            src={layer.src}
+            alt={layer.alt || `parallax-layer-${idx}`}
+            fill
+            className="object-cover"
+            priority={idx === 0}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ParallaxScroll;


### PR DESCRIPTION
## Summary
- add `ParallaxScroll` component rendering layered images with scroll-driven transforms

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_68a74e8aa11c8329b28337d74a3c0c3d